### PR TITLE
Fixed way subunit's icons are displayed:

### DIFF
--- a/bicemodded/common/defines/00_defines.lua
+++ b/bicemodded/common/defines/00_defines.lua
@@ -521,7 +521,7 @@ NProduction = {
 },
 
 NTechnology = {
-	MAX_SUBTECHS = 3,					    -- Max number of sub technologies a technology can have.
+	MAX_SUBTECHS = 4,					    -- Max number of sub technologies a technology can have.
 	BASE_RESEARCH_POINTS_SAVED = 50.0,		-- Base amount of research points a country can save per slot.
 	BASE_YEAR_AHEAD_PENALTY_FACTOR = 2.5,		-- 3 Base year ahead penalty
 	BASE_TECH_COST = 97,					-- base cost for a tech. multiplied with tech cost and ahead of time penalties

--- a/bicemodded/common/technologies/ENG_armor.txt
+++ b/bicemodded/common/technologies/ENG_armor.txt
@@ -2959,7 +2959,7 @@ technologies = {
 		enable_subunits = {
 			super_heavy_sp_artillery_brigade
 		}
-		
+		sub_tech_index = 1
 	
 		research_cost = 1.8
 		start_year = 1943
@@ -3010,7 +3010,7 @@ technologies = {
 		enable_equipments = {
 			super_uk_heavy_tank_artillery_equipment_2
 		}
-	
+		sub_tech_index = 1
 		research_cost = 1.8
 		start_year = 1945
 		

--- a/bicemodded/common/technologies/GER_armor.txt
+++ b/bicemodded/common/technologies/GER_armor.txt
@@ -2080,6 +2080,7 @@ technologies = {
 		}
 	}
 	#Subtechs
+	#StuG IV
 	subtech_panzer_iv_td_equipment_1 = {
 
 		enable_equipments = {
@@ -2088,6 +2089,7 @@ technologies = {
 		enable_subunits = {
 			medium_tank_destroyer_brigade
 		}
+		sub_tech_index = 0
 		on_research_complete = {
 	    	hidden_effect = {
 				if = {
@@ -2117,6 +2119,7 @@ technologies = {
 			cat_med_td
 		}
 	}
+	#Brummbar
 	subtech_panzer_iv_ag_equipment_1 = {
 
 		enable_equipments = {
@@ -2125,7 +2128,7 @@ technologies = {
 		enable_subunits = {
 			modern_sp_artillery_brigade
 		}
-	
+		sub_tech_index = 3
 		dependencies = {
 			artillery3 = 1
 		}
@@ -2153,6 +2156,7 @@ technologies = {
 			factor = 0
 		}
 	}
+	#Wirbelwind
 	subtech_panzer_iv_spaa_equipment_2 = {
 
 		enable_equipments = {
@@ -2162,7 +2166,7 @@ technologies = {
 		dependencies = {
 			antiair2 = 1
 		}
-
+		sub_tech_index = 2
 		research_cost = 1.3
 		start_year = 1942
 		
@@ -2962,7 +2966,7 @@ technologies = {
 		enable_subunits = {
 			modern_tank_destroyer_brigade
 		}
-
+		sub_tech_index = 3
 		dependencies = {
 			artillery3 = 1
 		}
@@ -3060,7 +3064,7 @@ technologies = {
 		enable_equipments = {
 			panzer_vi_ag_equipment_2
 		}
-	
+		sub_tech_index = 3
 
 		dependencies = {
 			artillery5 = 1
@@ -3320,7 +3324,7 @@ technologies = {
 		enable_subunits = {
 			super_heavy_sp_artillery_brigade
 		}
-	
+		sub_tech_index = 1
 		research_cost = 1.8
 		start_year = 1943
 		
@@ -3385,7 +3389,7 @@ technologies = {
 		enable_equipments = {
 			super_heavy_tank_artillery_equipment_2
 		}
-	
+		sub_tech_index = 1
 		research_cost = 1.8
 		start_year = 1945
 		

--- a/bicemodded/common/technologies/SOV_armor.txt
+++ b/bicemodded/common/technologies/SOV_armor.txt
@@ -782,7 +782,7 @@ technologies = {
 		enable_subunits = {
 			medium_sp_artillery_brigade
 		}
-		
+		sub_tech_index = 1
 		research_cost = 1.5
 		start_year = 1939
 		
@@ -2118,7 +2118,7 @@ technologies = {
 		enable_subunits = {
     		super_heavy_sp_artillery_brigade
 		}
-	
+		sub_tech_index = 1
 		research_cost = 1.8
 		start_year = 1943
 		
@@ -2168,7 +2168,7 @@ technologies = {
 		enable_equipments = {
 			super_heavy_tank_artillery_equipment_2
 		}
-	
+		sub_tech_index = 1
 		research_cost = 1.8
 		start_year = 1945
 		

--- a/bicemodded/interface/countrytechtreeview.gui
+++ b/bicemodded/interface/countrytechtreeview.gui
@@ -10714,24 +10714,24 @@ guiTypes = {
 				alwaystransparent = yes
 			}
 		}
-	#	containerWindowType = {
-	#		name = "sub_technology_slot_3" #Assault Gun
-	#		position = { x=141 y=-26 }
-	#		size = { width = 35 height = 26 }
-	#		clipping = no
-	#		
-	#		background = {
-	#			name = "Background"
-	#			spriteType ="GFX_subtechnology_unavailable_item_bg"
-	#		}
-	#		
-	#		iconType = {
-	#			name = "picture"
-	#			position = { x=1 y=2 }
-	#			spriteType = "GFX_subtech_assault" 
-	#			alwaystransparent = yes
-	#		}
-	#	}
+		containerWindowType = {
+			name = "sub_technology_slot_3" #Assault Gun
+			position = { x=1 y=55 }
+			size = { width = 35 height = 26 }
+			clipping = no
+			
+			background = {
+				name = "Background"
+				spriteType ="GFX_subtechnology_unavailable_item_bg"
+			}
+			
+			iconType = {
+				name = "picture"
+				position = { x=1 y=2 }
+				spriteType = "GFX_subtech_assault" 
+				alwaystransparent = yes
+			}
+		}
 	}
 	# German techtree air
 	containerWindowType = {


### PR DESCRIPTION
- modified defines/00_defines.lua to accomodate 4th subunit type
- enabled 4th icon (!!GFX is still missing!!) for assault gun - will be shown in down-left corner if needed
- fixed displaying wrong subunit icons for GER_armor.txt, SOV_armor.txt, ENG_armor.txt when not all subunit types are researchable