### PR TITLE
FIX Romania focus invite ger advisors

### DIFF
--- a/bicemodded/common/national_focus/romania.txt
+++ b/bicemodded/common/national_focus/romania.txt
@@ -373,11 +373,7 @@
 		completion_reward = {
 			custom_effect_tooltip = ROM_invite_german_advisors_tt
 			hidden_effect = {
-				diplomatic_relation = {
-					country = GER
-					relation = military_access
-					active = yes
-				}
+				ROM = { give_military_access = GER }
 			}
 			add_to_tech_sharing_group = ROM_invite_german_advisors_tech_group
 			GER = { add_to_tech_sharing_group = ROM_invite_german_advisors_tech_group }


### PR DESCRIPTION
Current Romania focus "Invite German Advisors" should has effect "Permit Germany to station troops on Romanian soil."
But it has opposite effect, it gives Romania military access into Germany. 
This fixes the issue, gives Germany military access into Romania. Tested.